### PR TITLE
Changed SelectInEnvelopeFunc to select indexed envelopes inside the p…

### DIFF
--- a/rstar/src/algorithm/selection_functions.rs
+++ b/rstar/src/algorithm/selection_functions.rs
@@ -41,7 +41,7 @@ where
     type ContainmentUnit = T::Envelope;
 
     fn is_contained_in(&self, envelope: &T::Envelope) -> bool {
-        envelope.contains_envelope(&self.envelope)
+        self.envelope.contains_envelope(&envelope)
     }
 }
 


### PR DESCRIPTION
…rovided envelope

Rather than the reverse (find all indexed envelopes that have the provided envelope contained inside). Which may be useful, but I don't believe is the intent of this query. Evidenced by SelectInEnvelopeFuncIntersecting not being that way.

---------------

If I'm completely lost, and this was the intent of that function, please let me know and I'll write a pull request to add function to allow a query of indexed envelopes inside the provided one. (Which is the function I need).

Many thanks,
Bryan