### PR TITLE
Rename feature serde_serialize to serde.

### DIFF
--- a/rstar/Cargo.toml
+++ b/rstar/Cargo.toml
@@ -20,13 +20,11 @@ maintenance = { status = "actively-developed" }
 num-traits = "0.2"
 pdqselect = "0.1"
 threadpool = "1.7"
-serde = { version = "1.0", optional = true }
-serde_derive = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [features]
 default = []
 debug = []
-serde_serialize = ["serde", "serde_derive"]
 
 [dev-dependencies]
 rand = "0.6"

--- a/rstar/README.md
+++ b/rstar/README.md
@@ -19,7 +19,7 @@ A flexible, n-dimensional [r*-tree](https://en.wikipedia.org/wiki/R*_tree) imple
    - Lines
    - Rectangles
  - Small number of dependencies
- - Serde support with the `serde_serialize` feature
+ - Serde support with the `serde` feature
 
 # Project state
 The project is being actively developed, feature requests and PRs are welcome!

--- a/rstar/src/lib.rs
+++ b/rstar/src/lib.rs
@@ -18,7 +18,7 @@
 //! the [primitives module](primitives/index.html) may be of interest for a quick start.
 //!
 //! # (De)Serialization
-//! Enable the `serde` for [Serde](https://crates.io/crates/serde) support.
+//! Enable the `serde` feature for [Serde](https://crates.io/crates/serde) support.
 //!
 #![deny(missing_docs)]
 mod algorithm;

--- a/rstar/src/lib.rs
+++ b/rstar/src/lib.rs
@@ -18,7 +18,7 @@
 //! the [primitives module](primitives/index.html) may be of interest for a quick start.
 //!
 //! # (De)Serialization
-//! Enable the `serde_serialize` for [Serde](https://crates.io/crates/serde) support.
+//! Enable the `serde` for [Serde](https://crates.io/crates/serde) support.
 //!
 #![deny(missing_docs)]
 mod algorithm;

--- a/rstar/src/primitives/line.rs
+++ b/rstar/src/primitives/line.rs
@@ -23,10 +23,7 @@ use num_traits::{One, Zero};
 /// assert!(tree.contains(&line_1));
 /// ```
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(
-    feature = "serde_serialize",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Line<P>
 where
     P: Point,

--- a/rstar/src/primitives/rectangle.rs
+++ b/rstar/src/primitives/rectangle.rs
@@ -13,10 +13,7 @@ use crate::structures::aabb::AABB;
 /// # Type parameters
 /// `P`: The rectangle's point type.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(
-    feature = "serde_serialize",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rectangle<P>
 where
     P: Point,

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -9,7 +9,7 @@ use crate::params::{DefaultParams, InsertionStrategy, RTreeParams};
 use crate::structures::node::ParentNodeData;
 use crate::Point;
 
-#[cfg(feature = "serde_serialize")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 impl<T> Default for RTree<T>
@@ -125,15 +125,12 @@ where
 /// is contained `n` times), the performance of most operations usually degrades to `O(n)`.
 ///
 /// # (De)Serialization
-/// Enable the `serde_serialize` for [Serde](https://crates.io/crates/serde) support.
+/// Enable the `serde` for [Serde](https://crates.io/crates/serde) support.
 ///
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    feature = "serde_serialize",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
-#[cfg_attr(
-    feature = "serde_serialize",
+    feature = "serde",
     serde(bound(
         serialize = "T: Serialize, T::Envelope: Serialize",
         deserialize = "T: Deserialize<'de>, T::Envelope: Deserialize<'de>"
@@ -708,7 +705,7 @@ mod test {
         assert_eq!(debug, "RTree { size: 2, items: {[0, 1], [0, 1]} }");
     }
 
-    #[cfg(feature = "serde_serialize")]
+    #[cfg(feature = "serde")]
     #[test]
     fn test_serialization() {
         use serde_json;

--- a/rstar/src/structures/aabb.rs
+++ b/rstar/src/structures/aabb.rs
@@ -2,8 +2,8 @@ use crate::point::{max_inline, Point, PointExt};
 use crate::{Envelope, RTreeObject};
 use num_traits::{Bounded, One, Signed, Zero};
 
-#[cfg(feature = "serde_serialize")]
-use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// An n-dimensional axis aligned bounding box (AABB).
 ///
@@ -11,7 +11,7 @@ use serde_derive::{Deserialize, Serialize};
 /// while being aligned to the current coordinate system.
 /// Although these structures are commonly called bounding _boxes_, they exist in any
 /// dimension.
-///  
+///
 /// Note that AABBs cannot be inserted into r-trees. Use the
 /// [Rectangle](primitives/struct.Rectangle.html) struct for this purpose.
 ///
@@ -19,7 +19,7 @@ use serde_derive::{Deserialize, Serialize};
 /// `P`: The struct is generic over which point type is used. Using an n-dimensional point
 /// type will result in an n-dimensional bounding box.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Ord, PartialOrd)]
-#[cfg_attr(feature = "serde_serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AABB<P>
 where
     P: Point,

--- a/rstar/src/structures/node.rs
+++ b/rstar/src/structures/node.rs
@@ -2,16 +2,13 @@ use crate::envelope::Envelope;
 use crate::object::RTreeObject;
 use crate::params::RTreeParams;
 
-#[cfg(feature = "serde_serialize")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    feature = "serde_serialize",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
-#[cfg_attr(
-    feature = "serde_serialize",
+    feature = "serde",
     serde(bound(
         serialize = "T: Serialize, T::Envelope: Serialize",
         deserialize = "T: Deserialize<'de>, T::Envelope: Deserialize<'de>"
@@ -30,10 +27,7 @@ where
 }
 
 #[derive(Debug, Clone)]
-#[cfg_attr(
-    feature = "serde_serialize",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ParentNodeData<T>
 where
     T: RTreeObject,


### PR DESCRIPTION
This follows the recommendation of the serde crate, which is to use
the derive feature rather than depending directly on serde_derive.

This is a breaking change for users of the serde feature, since it
changes the feature name.