### PR TITLE
Intersection improvements

### DIFF
--- a/rstar/Cargo.toml
+++ b/rstar/Cargo.toml
@@ -20,6 +20,7 @@ maintenance = { status = "actively-developed" }
 num-traits = "0.2"
 pdqselect = "0.1"
 serde = { version = "1.0", optional = true, features = ["derive"] }
+itertools = "0.8"
 
 [features]
 default = []

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -267,9 +267,9 @@ where
         RTreeIterator::new(&self.root, SelectAllFunc)
     }
 
-    /// Returns an iterator over all mutable elements contained in the tree.nearest_neighbor
+    /// Returns an iterator over all mutable elements contained in the tree.
     ///
-    /// The order in which the elements are returned is not specified.nearest_neighbor
+    /// The order in which the elements are returned is not specified.
     ///
     /// *Note*: It is a logic error to change an inserted item's position or dimensions. This
     /// method is primarily meant for own implementations of [RTreeObject](trait.RTreeObject.html)


### PR DESCRIPTION
This is a WIP; I'm very interested in feedback on how to do this correctly in Rust :).

1. I've added an `RTreeObject.intersects(other: RTreeObject)` method, which checks if this obj's envelope intersects other's envelope.  This is syntactic sugar to make a common operation more readable.  **However**, it's not as useful as I hoped, because although RTreeNode implements RTreeObject, Leaf and Parent don't directly, so any intersection involving them has to write out the logic explicitly.  There might be a cool way to push down the derived `intersects` method to the enum members, but my explorations didn't find one :(.  Options that I see include:
  A. Leave it as it is,
  B. Implement `intersects` (or `intersects_envelope`) on Leaf and Parent, or
  C. Refactor to have an `Enveloped` trait that requires an `envelope()` method, and has a default implementation of `intersects_envelope()` that does the "right" thing.  I started to do this refactor, but it was getting involved and so I stopped shaving yaks.  I think there might be some good discussion about whether this would be useful, and if so, the right way to do it.

2. I've refactored the IntersectionIterator to enforce the invariant condition that the todo stack only includes items whose envelopes intersect.  While this implementation works (up to tests), it's not as slick as I wanted, largely because I couldn't make a `&RTreeNode` out of a `&ParentNode`.  If the ParentNode wasn't a reference, I could just make `RTreeNode::Parent(parent_node)`, but I couldn't get the ownership to work out given the reference returned by `RTree.root()`.  There's likely a way to make it work, if my mental model was better!

3. I also pruned some overly eager autocompletion.