### PR TITLE
Distance iterator

### DIFF
--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -611,6 +611,14 @@ where
     ) -> impl Iterator<Item = &T> {
         nearest_neighbor::NearestNeighborIterator::new(&self.root, *query_point)
     }
+
+    /// Returns `(element, distance)` tuples of the tree sorted by their distance to a given point.
+    pub fn nearest_neighbor_iter_with_distance(
+        &self,
+        query_point: &<T::Envelope as Envelope>::Point,
+    ) -> impl Iterator<Item = (&T, <<T::Envelope as Envelope>::Point as Point>::Scalar)> {
+        nearest_neighbor::NearestNeighborDistanceIterator::new(&self.root, *query_point)
+    }
 }
 
 impl<T, Params> RTree<T, Params>


### PR DESCRIPTION
I was looking for a way to retrieve the distances of nearest neighbors but it seems like it needs to be recalculated every time. Is there a way to do this with the current API? Given that the user's `distance_2` function could be arbitrarily complex/expensive, it would be helpful to avoid this recalculation.

I added a new iterator `NearestNeighborDistanceIterator` which emits the underlying distances that preserve ordering in the heap, and made the original `NearestNeighborIterator` into a wrapper for this iterator.