### PR TITLE
Allow intersections to work with different objects

### DIFF
--- a/rstar/src/algorithm/intersection_iterator.rs
+++ b/rstar/src/algorithm/intersection_iterator.rs
@@ -4,18 +4,20 @@ use crate::RTreeNode;
 use crate::RTreeNode::*;
 use crate::RTreeObject;
 
-pub struct IntersectionIterator<'a, T>
+pub struct IntersectionIterator<'a, T, U=T>
 where
     T: RTreeObject,
+    U: RTreeObject,
 {
-    todo_list: Vec<(&'a RTreeNode<T>, &'a RTreeNode<T>)>,
+    todo_list: Vec<(&'a RTreeNode<T>, &'a RTreeNode<U>)>,
 }
 
-impl<'a, T> IntersectionIterator<'a, T>
+impl<'a, T, U> IntersectionIterator<'a, T, U>
 where
     T: RTreeObject,
+    U: RTreeObject<Envelope=T::Envelope>,
 {
-    pub(crate) fn new(root1: &'a ParentNode<T>, root2: &'a ParentNode<T>) -> Self {
+    pub(crate) fn new(root1: &'a ParentNode<T>, root2: &'a ParentNode<U>) -> Self {
         let mut intersections = IntersectionIterator {
             todo_list: Vec::new(),
         };
@@ -23,7 +25,7 @@ where
         intersections
     }
 
-    fn push_if_intersecting(&mut self, node1: &'a RTreeNode<T>, node2: &'a RTreeNode<T>) {
+    fn push_if_intersecting(&mut self, node1: &'a RTreeNode<T>, node2: &'a RTreeNode<U>) {
         if node1.envelope().intersects(&node2.envelope()) {
             self.todo_list.push((node1, node2));
         }
@@ -32,7 +34,7 @@ where
     fn add_intersecting_children(
         &mut self,
         parent1: &'a ParentNode<T>,
-        parent2: &'a ParentNode<T>,
+        parent2: &'a ParentNode<U>,
     ) {
         if !parent1.envelope().intersects(&parent2.envelope()) {
             return;
@@ -55,17 +57,23 @@ where
     }
 }
 
-impl<'a, T> Iterator for IntersectionIterator<'a, T>
+impl<'a, T, U> Iterator for IntersectionIterator<'a, T, U>
 where
     T: RTreeObject,
+    U: RTreeObject<Envelope=T::Envelope>
 {
-    type Item = (&'a T, &'a T);
+    type Item = (&'a T, &'a U);
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(next) = self.todo_list.pop() {
             match next {
                 (Leaf(t1), Leaf(t2)) => return Some((&t1, &t2)),
-                (leaf @ Leaf(_), Parent(p)) | (Parent(p), leaf @ Leaf(_)) => {
+                (leaf @ Leaf(_), Parent(p)) => {
+                    p.children()
+                        .iter()
+                        .for_each(|c| self.push_if_intersecting(leaf, c));
+                },
+                (Parent(p), leaf @ Leaf(_)) => {
                     p.children()
                         .iter()
                         .for_each(|c| self.push_if_intersecting(c, leaf));

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -391,10 +391,13 @@ where
     ///
     /// This will return all objects whose _envelopes_ intersect. No geometric intersection
     /// checking is performed.
-    pub fn intersection_candidates_with_other_tree<'a>(
+    pub fn intersection_candidates_with_other_tree<'a, U>(
         &'a self,
-        other: &'a Self,
-    ) -> IntersectionIterator<T> {
+        other: &'a RTree<U>,
+    ) -> IntersectionIterator<T, U>
+    where
+        U: RTreeObject<Envelope=T::Envelope>
+    {
         IntersectionIterator::new(self.root(), other.root())
     }
 


### PR DESCRIPTION
Only the envelopes are used for determining intersection candidates, so it suffices that the envelopes of the two objects are of the same type.

This would resolve #23. The changes here also have the very fortunate side effect of making sure that `intersection_candidates` always gives tuples `(object1, object2`)`, i.e. so that objects from tree `self` always come first in the returned tuples, and objects from tree 2 come from the `other` tree. Before, it was not possible to distinguish which object came from which tree.

I haven't added any new tests, and I haven't adjusted the documentation, but I could do both. For this, I'll wait for your feedback. I otherwise don't think it should cause any issues in existing code, because the new code is a strict generalization. As I pointed out above, however, it *does* change the order in the tuples returned, but I can't really imagine how any code could be relying on this anyway?

Let me know what you think!