### PR TITLE
No std support

### DIFF
--- a/rstar/Cargo.toml
+++ b/rstar/Cargo.toml
@@ -17,13 +17,16 @@ codecov = { repository = "Stoeoef/rstar", branch = "master", service = "github" 
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-num-traits = "0.2"
-pdqselect = "0.1"
+num-traits = { version = "0.2", default-features = false, features = ["libm"] }
+pdqselect = { version = "0.1", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [features]
-default = []
+default = ["std"]
 debug = []
+std = [
+    "num-traits/std"
+]
 
 [dev-dependencies]
 rand = "0.7"

--- a/rstar/src/algorithm/bulk_load/bulk_load_sequential.rs
+++ b/rstar/src/algorithm/bulk_load/bulk_load_sequential.rs
@@ -4,6 +4,7 @@ use crate::object::RTreeObject;
 use crate::params::RTreeParams;
 use crate::point::Point;
 use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
 use num_traits::float::Float;
 
 use super::cluster_group_iterator::{calculate_number_of_clusters_on_axis, ClusterGroupIterator};

--- a/rstar/src/algorithm/bulk_load/bulk_load_sequential.rs
+++ b/rstar/src/algorithm/bulk_load/bulk_load_sequential.rs
@@ -3,6 +3,8 @@ use crate::node::{ParentNode, RTreeNode};
 use crate::object::RTreeObject;
 use crate::params::RTreeParams;
 use crate::point::Point;
+use alloc::vec::Vec;
+use num_traits::float::Float;
 
 use super::cluster_group_iterator::{calculate_number_of_clusters_on_axis, ClusterGroupIterator};
 
@@ -47,7 +49,7 @@ struct PartitioningTask<T: RTreeObject, Params: RTreeParams> {
     work_queue: Vec<PartitioningState<T>>,
     depth: usize,
     number_of_clusters_on_axis: usize,
-    _params: std::marker::PhantomData<Params>,
+    _params: core::marker::PhantomData<Params>,
 }
 
 impl<T: RTreeObject, Params: RTreeParams> Iterator for PartitioningTask<T, Params> {
@@ -99,9 +101,9 @@ where
 mod test {
     use crate::test_utilities::*;
     use crate::{Point, RTree, RTreeObject};
-    use std::collections::HashSet;
-    use std::fmt::Debug;
-    use std::hash::Hash;
+    use core::collections::HashSet;
+    use core::fmt::Debug;
+    use core::hash::Hash;
 
     #[test]
     fn test_bulk_load_small() {

--- a/rstar/src/algorithm/bulk_load/cluster_group_iterator.rs
+++ b/rstar/src/algorithm/bulk_load/cluster_group_iterator.rs
@@ -1,5 +1,6 @@
 use crate::{Envelope, Point, RTreeObject, RTreeParams};
 use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
 use num_traits::float::Float;
 /// Partitions elements into groups of clusters along a specific axis.
 pub struct ClusterGroupIterator<T: RTreeObject> {

--- a/rstar/src/algorithm/bulk_load/cluster_group_iterator.rs
+++ b/rstar/src/algorithm/bulk_load/cluster_group_iterator.rs
@@ -1,5 +1,6 @@
 use crate::{Envelope, Point, RTreeObject, RTreeParams};
-
+use alloc::vec::Vec;
+use num_traits::float::Float;
 /// Partitions elements into groups of clusters along a specific axis.
 pub struct ClusterGroupIterator<T: RTreeObject> {
     remaining: Vec<T>,
@@ -28,12 +29,12 @@ impl<T: RTreeObject> Iterator for ClusterGroupIterator<T> {
     fn next(&mut self) -> Option<Self::Item> {
         match self.remaining.len() {
             0 => None,
-            len if len <= self.slab_size => ::std::mem::replace(&mut self.remaining, vec![]).into(),
+            len if len <= self.slab_size => ::core::mem::replace(&mut self.remaining, vec![]).into(),
             _ => {
                 let slab_axis = self.cluster_dimension;
                 T::Envelope::partition_envelopes(slab_axis, &mut self.remaining, self.slab_size);
                 let off_split = self.remaining.split_off(self.slab_size);
-                ::std::mem::replace(&mut self.remaining, off_split).into()
+                ::core::mem::replace(&mut self.remaining, off_split).into()
             }
         }
     }

--- a/rstar/src/algorithm/intersection_iterator.rs
+++ b/rstar/src/algorithm/intersection_iterator.rs
@@ -3,7 +3,7 @@ use crate::Envelope;
 use crate::RTreeNode;
 use crate::RTreeNode::*;
 use crate::RTreeObject;
-
+use alloc::vec::Vec;
 pub struct IntersectionIterator<'a, T, U = T>
 where
     T: RTreeObject,

--- a/rstar/src/algorithm/iterators.rs
+++ b/rstar/src/algorithm/iterators.rs
@@ -1,7 +1,7 @@
 use crate::algorithm::selection_functions::*;
 use crate::node::{ParentNode, RTreeNode};
 use crate::object::RTreeObject;
-
+use alloc::vec::Vec;
 pub type LocateAllAtPoint<'a, T> = SelectionIterator<'a, T, SelectAtPointFunction<T>>;
 pub type LocateAllAtPointMut<'a, T> = SelectionIteratorMut<'a, T, SelectAtPointFunction<T>>;
 pub type LocateInEnvelope<'a, T> = SelectionIterator<'a, T, SelectInEnvelopeFunction<T>>;

--- a/rstar/src/algorithm/nearest_neighbor.rs
+++ b/rstar/src/algorithm/nearest_neighbor.rs
@@ -2,7 +2,7 @@ use crate::node::{ParentNode, RTreeNode};
 use crate::point::{min_inline, Point};
 use crate::{Envelope, PointDistance, RTreeObject};
 use num_traits::Bounded;
-use std::collections::binary_heap::BinaryHeap;
+use alloc::collections::binary_heap::BinaryHeap;
 
 struct RTreeNodeDistanceWrapper<'a, T>
 where
@@ -25,7 +25,7 @@ impl<'a, T> PartialOrd for RTreeNodeDistanceWrapper<'a, T>
 where
     T: PointDistance,
 {
-    fn partial_cmp(&self, other: &Self) -> Option<::std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
         // Inverse comparison creates a min heap
         other.distance.partial_cmp(&self.distance)
     }
@@ -37,7 +37,7 @@ impl<'a, T> Ord for RTreeNodeDistanceWrapper<'a, T>
 where
     T: PointDistance,
 {
-    fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> ::core::cmp::Ordering {
         self.partial_cmp(other).unwrap()
     }
 }
@@ -224,7 +224,7 @@ mod test {
         let sample_points = create_random_points(100, SEED_2);
         for sample_point in &sample_points {
             let mut nearest = None;
-            let mut closest_dist = ::std::f64::INFINITY;
+            let mut closest_dist = ::core::f64::INFINITY;
             for point in &points {
                 let delta = [point[0] - sample_point[0], point[1] - sample_point[1]];
                 let new_dist = delta[0] * delta[0] + delta[1] * delta[1];

--- a/rstar/src/algorithm/rstar.rs
+++ b/rstar/src/algorithm/rstar.rs
@@ -6,6 +6,7 @@ use crate::point::{Point, PointExt};
 use crate::rtree::RTree;
 use num_traits::{Bounded, Zero};
 
+use alloc::vec::Vec;
 /// Inserts points according to the r-star heuristic.
 ///
 /// The r*-heuristic focusses on good insertion quality at the costs of
@@ -39,7 +40,7 @@ impl InsertionStrategy for RStarInsertionStrategy {
                 InsertionResult::Split(node) => {
                     // The root node was split, create a new root and increase height
                     let new_root = ParentNode::new_root::<Params>();
-                    let old_root = ::std::mem::replace(tree.root_mut(), new_root);
+                    let old_root = ::core::mem::replace(tree.root_mut(), new_root);
                     let new_envelope = old_root.envelope.merged(&node.envelope());
                     let root = tree.root_mut();
                     root.envelope = new_envelope;

--- a/rstar/src/algorithm/selection_functions.rs
+++ b/rstar/src/algorithm/selection_functions.rs
@@ -237,6 +237,6 @@ where
     }
 
     fn should_unpack_leaf(&self, leaf: &T) -> bool {
-        std::ptr::eq(self.element_address, leaf)
+        core::ptr::eq(self.element_address, leaf)
     }
 }

--- a/rstar/src/envelope.rs
+++ b/rstar/src/envelope.rs
@@ -6,7 +6,7 @@ use crate::{Point, RTreeObject};
 /// e.g. how they can be merged or intersected.
 /// This trait is not meant to be implemented by the user. Currently, only one implementation
 /// exists ([AABB](struct.AABB.html)) and should be used.
-pub trait Envelope: Clone + Copy + PartialEq + ::std::fmt::Debug {
+pub trait Envelope: Clone + Copy + PartialEq + ::core::fmt::Debug {
     /// The envelope's point type.
     type Point: Point;
 

--- a/rstar/src/lib.rs
+++ b/rstar/src/lib.rs
@@ -22,6 +22,10 @@
 //!
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[macro_use]
+extern crate alloc;
 
 mod aabb;
 mod algorithm;

--- a/rstar/src/node.rs
+++ b/rstar/src/node.rs
@@ -1,6 +1,7 @@
 use crate::envelope::Envelope;
 use crate::object::RTreeObject;
 use crate::params::RTreeParams;
+use alloc::vec::Vec;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/rstar/src/point.rs
+++ b/rstar/src/point.rs
@@ -1,5 +1,5 @@
 use num_traits::{Bounded, Num, Signed, Zero};
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 /// Defines a number type that is compatible with rstar.
 ///

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -10,6 +10,8 @@ use crate::object::{PointDistance, RTreeObject};
 use crate::params::{verify_parameters, DefaultParams, InsertionStrategy, RTreeParams};
 use crate::Point;
 
+use alloc::vec::Vec;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -145,33 +147,33 @@ where
 {
     root: ParentNode<T>,
     size: usize,
-    _params: ::std::marker::PhantomData<Params>,
+    _params: ::core::marker::PhantomData<Params>,
 }
 
 struct DebugHelper<'a, T, Params>
 where
-    T: RTreeObject + ::std::fmt::Debug + 'a,
+    T: RTreeObject + ::core::fmt::Debug + 'a,
     Params: RTreeParams + 'a,
 {
     rtree: &'a RTree<T, Params>,
 }
 
-impl<'a, T, Params> ::std::fmt::Debug for DebugHelper<'a, T, Params>
+impl<'a, T, Params> ::core::fmt::Debug for DebugHelper<'a, T, Params>
 where
-    T: RTreeObject + ::std::fmt::Debug,
+    T: RTreeObject + ::core::fmt::Debug,
     Params: RTreeParams,
 {
-    fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         formatter.debug_set().entries(self.rtree.iter()).finish()
     }
 }
 
-impl<T, Params> ::std::fmt::Debug for RTree<T, Params>
+impl<T, Params> ::core::fmt::Debug for RTree<T, Params>
 where
     Params: RTreeParams,
-    T: RTreeObject + ::std::fmt::Debug,
+    T: RTreeObject + ::core::fmt::Debug,
 {
-    fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         formatter
             .debug_struct("RTree")
             .field("size", &self.size)


### PR DESCRIPTION
This PR provides no_std support for rstar crate.
It makes use of (now stable) `alloc`