### PR TITLE
Clarify squared nature of distances returned by nearest_neighbor_iter_with_distance 

### DIFF
--- a/rstar/src/algorithm/nearest_neighbor.rs
+++ b/rstar/src/algorithm/nearest_neighbor.rs
@@ -255,14 +255,14 @@ mod test {
     }
 
     #[test]
-    fn test_nearest_neighbor_iterator_with_distance() {
+    fn test_nearest_neighbor_iterator_with_distance_2() {
         let points = create_random_points(1000, SEED_2);
         let tree = RTree::bulk_load(points.clone());
 
         let sample_points = create_random_points(50, SEED_1);
         for sample_point in &sample_points {
             let mut last_distance = 0.0;
-            for (point, distance) in tree.nearest_neighbor_iter_with_distance(&sample_point) {
+            for (point, distance) in tree.nearest_neighbor_iter_with_distance_2(&sample_point) {
                 assert_eq!(point.distance_2(sample_point), distance);
                 assert!(last_distance < distance);
                 last_distance = distance;

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -658,7 +658,21 @@ where
     ///
     /// The distance is calculated by calling
     /// [PointDistance::distance_2](traits.PointDistance.html#method.distance_2).
+    #[deprecated(
+        note = "Please use nearest_neighbor_iter_with_distance_2 instead"
+    )]
     pub fn nearest_neighbor_iter_with_distance(
+        &self,
+        query_point: &<T::Envelope as Envelope>::Point,
+    ) -> impl Iterator<Item = (&T, <<T::Envelope as Envelope>::Point as Point>::Scalar)> {
+        nearest_neighbor::NearestNeighborDistanceIterator::new(&self.root, *query_point)
+    }
+
+    /// Returns `(element, distance^2)` tuples of the tree sorted by their distance to a given point.
+    ///
+    /// The distance is calculated by calling
+    /// [PointDistance::distance_2](traits.PointDistance.html#method.distance_2).
+    pub fn nearest_neighbor_iter_with_distance_2(
         &self,
         query_point: &<T::Envelope as Envelope>::Point,
     ) -> impl Iterator<Item = (&T, <<T::Envelope as Envelope>::Point as Point>::Scalar)> {

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -654,7 +654,10 @@ where
         nearest_neighbor::NearestNeighborIterator::new(&self.root, *query_point)
     }
 
-    /// Returns `(element, distance)` tuples of the tree sorted by their distance to a given point.
+    /// Returns `(element, distance^2)` tuples of the tree sorted by their distance to a given point.
+    ///
+    /// The distance is calculated by calling
+    /// [PointDistance::distance_2](traits.PointDistance.html#method.distance_2).
     pub fn nearest_neighbor_iter_with_distance(
         &self,
         query_point: &<T::Envelope as Envelope>::Point,


### PR DESCRIPTION
As per the poorly-worded feature request #31 .

The first commit just changes the documentation, the second renames the function (leaving the first with a deprecation annotation), in case you would prefer only the first. If you were to go down the renaming route, ideally I'd have changed the name of the iterator too, to `NearestNeighborDistance2Iterator`, but I was less clear on how to do so while still keeping the old around for deprecation.