### PR TITLE
Optimizations to nearest neighbor

### DIFF
--- a/rstar/Cargo.toml
+++ b/rstar/Cargo.toml
@@ -17,6 +17,7 @@ codecov = { repository = "Stoeoef/rstar", branch = "master", service = "github" 
 maintenance = { status = "actively-developed" }
 
 [dependencies]
+heapless = "0.5"
 num-traits = "0.2"
 pdqselect = "0.1"
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/rstar/src/point.rs
+++ b/rstar/src/point.rs
@@ -322,10 +322,12 @@ macro_rules! implement_point_for_array {
                 [$(generator($index)),*]
             }
 
+            #[inline]
             fn nth(&self, index: usize) -> Self::Scalar {
                 self[index]
             }
 
+            #[inline]
             fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
                 &mut self[index]
             }


### PR DESCRIPTION
Thanks for the great library! A few optimizations for our use case of querying hundreds of thousands of nodes in large (10-100K node) trees:

- Inline annotation on point indexing: surprised this is not happening automatically, but I receive consistent ~5% speedup with these.
- Optimizing min_max_dist_2 to use O(P::DIMENSIONS) multiplications rather than O(P::DIMENSIONS^2) multiplications. This doesn't do much for 2-D, but yields 15-20% speedup for our 3-D cases. Note that due to order of floating point operations, the result of the function is not identical to the previous version. If this is important, I have a slightly less elegant but same O() version I can substitute that gives identical results to the old version.
- Removing priority queue allocations from single nearest neighbor queries. When making many nearest neighbor queries, this has a large effect. For us, combined with the other optimizations this has a 1.5-1.8x speedup. It's also important for the performance of a follow-up PR I have go doing tree-to-tree all nearest neighbor queries.