### PR TITLE
RFC: Add support for internal iteration to avoid heap allocations

### DIFF
--- a/rstar-benches/benches/benchmarks.rs
+++ b/rstar-benches/benches/benchmarks.rs
@@ -79,14 +79,14 @@ fn tree_creation_quality(c: &mut Criterion) {
     c.bench_function("bulk load quality", move |b| {
         b.iter(|| {
             for query_point in &query_points {
-                tree_bulk_loaded.nearest_neighbor(&query_point).is_some();
+                tree_bulk_loaded.nearest_neighbor(&query_point).unwrap();
             }
         })
     })
     .bench_function("sequential load quality", move |b| {
         b.iter(|| {
             for query_point in &query_points_cloned_1 {
-                tree_sequential.nearest_neighbor(&query_point).is_some();
+                tree_sequential.nearest_neighbor(&query_point).unwrap();
             }
         });
     });
@@ -97,7 +97,7 @@ fn locate_successful(c: &mut Criterion) {
     let query_point = points[500];
     let tree = RTree::<_, Params>::bulk_load_with_params(points);
     c.bench_function("locate_at_point (successful)", move |b| {
-        b.iter(|| tree.locate_at_point(&query_point))
+        b.iter(|| tree.locate_at_point(&query_point).unwrap())
     });
 }
 
@@ -110,13 +110,33 @@ fn locate_unsuccessful(c: &mut Criterion) {
     });
 }
 
+fn locate_successful_internal(c: &mut Criterion) {
+    let points: Vec<_> = create_random_points(100_000, SEED_1);
+    let query_point = points[500];
+    let tree = RTree::<_, Params>::bulk_load_with_params(points);
+    c.bench_function("locate_at_point_int (successful)", move |b| {
+        b.iter(|| tree.locate_at_point_int(&query_point).unwrap())
+    });
+}
+
+fn locate_unsuccessful_internal(c: &mut Criterion) {
+    let points: Vec<_> = create_random_points(100_000, SEED_1);
+    let tree = RTree::<_, Params>::bulk_load_with_params(points);
+    let query_point = [0.7, 0.7];
+    c.bench_function("locate_at_point_int (unsuccessful)", move |b| {
+        b.iter(|| tree.locate_at_point(&query_point).is_none())
+    });
+}
+
 criterion_group!(
     benches,
     bulk_load_baseline,
     bulk_load_comparison,
     tree_creation_quality,
     locate_successful,
-    locate_unsuccessful
+    locate_unsuccessful,
+    locate_successful_internal,
+    locate_unsuccessful_internal
 );
 criterion_main!(benches);
 

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -472,6 +472,29 @@ where
         self.locate_all_at_point_mut(point).next()
     }
 
+    /// Variant of [locate_at_point](#method.locate_at_point) using internal iteration
+    pub fn locate_at_point_int(&self, point: &<T::Envelope as Envelope>::Point) -> Option<&T> {
+        let mut result = None;
+        self.locate_all_at_point_int(point, |node| {
+            result = Some(node);
+            true
+        });
+        result
+    }
+
+    /// Mutable variant of [locate_at_point_int](#method.locate_at_point_int)
+    pub fn locate_at_point_int_mut(
+        &mut self,
+        point: &<T::Envelope as Envelope>::Point,
+    ) -> Option<&mut T> {
+        let mut result = None;
+        self.locate_all_at_point_int_mut(point, |node| {
+            result = Some(node);
+            true
+        });
+        result
+    }
+
     /// Locate all elements containing a given point.
     ///
     /// Method [contains_point](trait.PointDistance.html#method.contains_point) is used
@@ -497,12 +520,38 @@ where
         LocateAllAtPoint::new(&self.root, SelectAtPointFunction::new(*point))
     }
 
-    /// Mutable variant of [locate_at_point_mut](#method.locate_at_point_mut).
+    /// Mutable variant of [locate_all_at_point](#method.locate_all_at_point).
     pub fn locate_all_at_point_mut(
         &mut self,
         point: &<T::Envelope as Envelope>::Point,
     ) -> LocateAllAtPointMut<T> {
         LocateAllAtPointMut::new(&mut self.root, SelectAtPointFunction::new(*point))
+    }
+
+    /// Variant of [locate_all_at_point](#method.locate_all_at_point) using internal iteration
+    pub fn locate_all_at_point_int<'a, Cons>(
+        &'a self,
+        point: &<T::Envelope as Envelope>::Point,
+        mut cons: Cons,
+    ) where
+        Cons: FnMut(&'a T) -> bool,
+    {
+        select_nodes(&self.root, &SelectAtPointFunction::new(*point), &mut cons);
+    }
+
+    /// Mutable variant of [locate_all_at_point_int](#method.locate_all_at_point_int)
+    pub fn locate_all_at_point_int_mut<'a, Cons>(
+        &'a mut self,
+        point: &<T::Envelope as Envelope>::Point,
+        mut cons: Cons,
+    ) where
+        Cons: FnMut(&'a mut T) -> bool,
+    {
+        select_nodes_mut(
+            &mut self.root,
+            &SelectAtPointFunction::new(*point),
+            &mut cons,
+        );
     }
 
     /// Removes an element containing a given point.


### PR DESCRIPTION
We are happily using rstar in ecological simulations of pollinator behavior as a spatial acceleration structure and have noticed at lot of memory allocator activity in our CPU profiles. While there does not seem to be a simple solution to avoid heap allocations for queries, this does provide one possible strategy: Using internal iteration to keep the necessary state on the regular stack. And while this does provide a strictly less versatile and less ergonomic API, it would be sufficient for our use cases.

Please let us know what you think of this approach and whether you would consider it for inclusion upstream. Thank you! (I did implement only the point queries as we only use those for now and the documentation certainly needs extension, especially detailing the increased stack usage.) 