### PR TITLE
Fine-tune iterator inline capacity to avoid memcpy call overhead

### DIFF
--- a/rstar/src/algorithm/iterators.rs
+++ b/rstar/src/algorithm/iterators.rs
@@ -23,7 +23,7 @@ where
     Func: SelectionFunction<T>,
 {
     func: Func,
-    current_nodes: SmallVec<[&'a RTreeNode<T>; 32]>,
+    current_nodes: SmallVec<[&'a RTreeNode<T>; 24]>,
 }
 
 impl<'a, T, Func> SelectionIterator<'a, T, Func>


### PR DESCRIPTION
While the change looks innocent, an inline capacity of 32 pointers does seem to induce LLVM to move these iterators around using calls to libc's `memcpy` instead of plain instructions - at least when using the Rust 1.45.0 nightly on x86-64.

Reducing the inline capacity to 24 avoids this effect and the associated call overhead but does not seem to trigger significantly more allocations. For our simulation model, this improves the number of time stamps per second by almost 5% (and reduces the `memcpy` calls from 5% CPU to negligible).