### PR TITLE
Add all-nearest-neighbors (a1NN) iterator for tree-to-tree lookup

### DIFF
--- a/rstar/src/envelope.rs
+++ b/rstar/src/envelope.rs
@@ -35,6 +35,9 @@ pub trait Envelope: Clone + Copy + PartialEq + ::std::fmt::Debug {
     /// Returns the euclidean distance to the envelope's border.
     fn distance_2(&self, point: &Self::Point) -> <Self::Point as Point>::Scalar;
 
+    /// Returns the minimum euclidean distance between this envelope and another.
+    fn min_dist_2(&self, other: &Self) -> <Self::Point as Point>::Scalar;
+
     /// Returns the squared min-max distance, a concept that helps to find nearest neighbors efficiently.
     ///
     /// Visually, if an AABB and a point are given, the min-max distance returns the distance at which we
@@ -43,6 +46,13 @@ pub trait Envelope: Clone + Copy + PartialEq + ::std::fmt::Debug {
     /// # References
     /// Roussopoulos, Nick, Stephen Kelley, and Frédéric Vincent. "Nearest neighbor queries." ACM sigmod record. Vol. 24. No. 2. ACM, 1995.
     fn min_max_dist_2(&self, point: &Self::Point) -> <Self::Point as Point>::Scalar;
+
+    /// Returns the squared euclidean distance such that for *any* point in this envelope,
+    /// we surely know that *an* element must be present in `other` envelope within
+    /// that distance.
+    ///
+    /// Note that this is not necessarily symmetric.
+    fn max_min_max_dist_2(&self, other: &Self) -> <Self::Point as Point>::Scalar;
 
     /// Returns the envelope's center point.
     fn center(&self) -> Self::Point;

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -611,6 +611,40 @@ where
         }
     }
 
+    /// Returns an iterator of the nearest neighbor in this tree for each node in a query tree.
+    ///
+    /// This method is more efficient than querying each node individually.
+    ///
+    /// # Example
+    /// ```
+    /// use rstar::RTree;
+    /// let target_tree = RTree::bulk_load(vec![
+    ///   [0.0, 0.0],
+    ///   [0.0, 1.0],
+    /// ]);
+    /// let query_tree = RTree::bulk_load(vec![
+    ///   [0.2, 0.7],
+    ///   [0.5, 0.0],
+    ///   [0.5, 1.0],
+    /// ]);
+    /// let mut ann = target_tree.all_nearest_neighbors(&query_tree)
+    ///     .map(|nn| (nn.query, nn.target))
+    ///     .collect::<Vec<_>>();
+    /// ann.sort_by(|(a, _), (b, _)| a.partial_cmp(b).unwrap());
+    /// assert_eq!(ann, &[
+    ///     // Query point, nearest neighbor
+    ///     (&[0.2, 0.7], &[0.0, 1.0]),
+    ///     (&[0.5, 0.0], &[0.0, 0.0]),
+    ///     (&[0.5, 1.0], &[0.0, 1.0]),
+    /// ]);
+    /// ```
+    pub fn all_nearest_neighbors<'a, P2: RTreeParams>(
+        &'a self,
+        query_tree: &'a RTree<T, P2>,
+    ) -> impl Iterator<Item=nearest_neighbor::NearestNeighbors<'a, 'a, T>> {
+        nearest_neighbor::all_nearest_neighbors(&self.root, query_tree.root())
+    }
+
     /// Returns all elements of the tree within a certain distance.
     ///
     /// The elements may be returned in any order. Each returned element


### PR DESCRIPTION
Add the ability to efficiently find the nearest neighbor in a target
tree for each point in a query tree. This works by traversing the query
tree depth-first and at each query tree node pruning nodes from the set
of candidate subtrees of the target tree that can not potentially hold
the nearest neighbors for any point in the query tree node.

This results in speedups on the order of 1.3x versus individual lookup
of the query points, and this speedup increases with the size and
dimensionality of the trees.

This all-nearest-neighbors or "a1NN" lookup is common in point cloud comparison algorithms, and is our primary use of `rstar`.

## The goods

```
$ cargo bench all
all to all tree lookup  time:   [372.09 us 375.74 us 379.91 us]                                   

...

all to all point lookup time:   [494.12 us 496.84 us 500.37 us]      
```

Note that this difference in performance grows as the trees get larger.

## Details of the algorithm

The algorithm works by traversing the query tree in DFS and keeping a stack of pruned subtrees of the the target tree for each depth of that traversal. These subtrees cover the potential nearest neighbors for any point in the query tree node at that depth. This allows points in the query tree to effectively reuse computation by only needing to search for their nearest neighbor in these subtrees.

The pruning works similarly to the existing pruning for single point lookups with `min_max_dist_2`, only instead of doing a point-to-envelope tight upper bound, we need to find an envelope-to-envelop tight upper bound. This is implemented in `Envelope::max_min_max_dist_2` for `AABB`. Conceptually it is the maximum over `min_max_dist_2` for any point in the envelope, and is naively implemented that way by iterating over the extrema (corners) of the envelope.

Here's an illustrative diagram:

![image](https://user-images.githubusercontent.com/460206/85031443-973f8080-b176-11ea-8ec2-e1c422d10ca8.png)

Here `p` is `A.max_min_max_dist_2(&B)` and `q` is `B.max_min_max_dist_2(&A)`. `m` is the maximum distance between the envelope, so that the diagram can prime your intuition that this distance can do better than that naive bound.

So for each query tree node we consider, we look at the candidate target subtrees of the parent (or children of those subtrees), and find the minimum `max_min_max_dist_2` of that set of subtrees. This means that for *any* point in the query node, there *must* be *a* nearest neighbor within that distance in some subtree. Thus we can prune any subtree whose *minimum* distance to the query node is greater than that distance.

For more details see the implementation. I tried to provide plenty of comments.

## Notes

- This depends on #40 for consistency in the distances used by the pruning, and tests will not pass until that PR is merged.
- There may be a clever optimization for `max_min_max_dist_2` like the one for `min_max_dist_2` in #35, but I haven't thought of it and am somewhat skeptical because of the combinatorial aspect.
- After coming up with this I did a quick lit survey and haven't found an exact match. The closest I've found so far is [this paper](https://www.cs.umd.edu/users/hjs/pubs/graphics-journal.pdf), but it differs in that:
  - It's not an R-tree
  - It's doing akNN rather than a1NN (more complicated, although this PR's approach could be generalized in a similar way)
  - It uses the less optimal maximum distance between envelopes
- Thanks to @clbarnes for feedback.